### PR TITLE
embed bootsrap css into Containerimage

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -26,6 +26,8 @@ WORKDIR /opt/go
 COPY --from=builder /build/scapinoculars .
 # Copy the Go templates, but this time from the repository
 COPY ./templates ./templates
+# Copy CSS, so that the reports are beautiful in offline environments
+ADD --chmod=644 https://cdn.jsdelivr.net/npm/bootstrap@3.4.1/dist/css/bootstrap.min.css ./styles/
 # We are using port 2112, also because why not
 EXPOSE 2112
 # We don't need root privileges, yay!

--- a/main.go
+++ b/main.go
@@ -28,6 +28,7 @@ const reportsOutputKey = "REPORT_OUTPUT_DIR"
 
 var reportDir = ""
 var reportOutputDir = ""
+var pwd, _ = os.Getwd()
 
 var reportData *reportdata.ReportData = &reportdata.ReportData{Reports: make(map[string]report.Report), Targets: []string{}, Profiles: []string{}}
 
@@ -36,7 +37,6 @@ func renderHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func indexHandler(w http.ResponseWriter, r *http.Request) {
-	pwd, _ := os.Getwd()
 	reportIndexTemplate, err := template.ParseFiles(pwd + "/templates/index.tmpl")
 	if err != nil {
 		log.Panicf("Could not open template file: %v", err)
@@ -305,6 +305,10 @@ func main() {
 	}()
 
 	http.HandleFunc("/", indexHandler)
+
+	styles := http.FileServer(http.Dir(pwd + "/styles"))
+	http.Handle("/styles/", http.StripPrefix("/styles/", styles))
+
 	reportserver := http.FileServer(http.Dir(reportOutputDir + "/"))
 	http.Handle("/reports/", http.StripPrefix("/reports/", reportserver))
 

--- a/templates/index.tmpl
+++ b/templates/index.tmpl
@@ -2,7 +2,7 @@
 <html>
   <head>
     <title>OpenSCAP Reports</title>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@3.4.1/dist/css/bootstrap.min.css" integrity="sha384-HSMxcRTRxnN+Bdg0JdbxYKrThecOKuH5zCYotlSAcp1+c8xmyTe9GYg1l9a69psu" crossorigin="anonymous">
+    <link rel="stylesheet" href="/styles/bootstrap.min.css" integrity="sha384-HSMxcRTRxnN+Bdg0JdbxYKrThecOKuH5zCYotlSAcp1+c8xmyTe9GYg1l9a69psu" crossorigin="anonymous">
   </head>
   <body>
      <!-- Fixed navbar -->


### PR DESCRIPTION
When you open SCAPinoculars in an environment without internet access, it cannot source bootstrap.css and its a little ugly.
This PR embeds the CSS
